### PR TITLE
Operators

### DIFF
--- a/src/compiler/src/compiler/visitor.rs
+++ b/src/compiler/src/compiler/visitor.rs
@@ -118,6 +118,7 @@ impl Compiler {
     /// Compile an expression
     fn expression(&mut self, syntax: &syntax::Expression) -> Result<()> {
         match syntax {
+            syntax::Expression::Binary(b) => self.binary(b),
             syntax::Expression::Block(b) => self.block(b),
             syntax::Expression::Call(c) => self.call(c),
             syntax::Expression::Function(f) => self.function(f),
@@ -126,7 +127,22 @@ impl Compiler {
             syntax::Expression::If(i) => self.if_else(i),
             syntax::Expression::List(l) => self.list(l),
             syntax::Expression::Literal(l) => self.literal(l),
+            syntax::Expression::Unary(u) => self.unary(u),
         }
+    }
+
+    /// Compile a binary operator expression.
+    fn binary(&mut self, _syntax: &syntax::Binary) -> Result<()> {
+        unimplemented!("operator compiling not yet implemented")
+    }
+
+    /// Compile a unary operator expression.
+    ///
+    /// We want to evaluate left-to-right, and we're not sure if retrieving a
+    /// definition of an operator could have side effects, so we need to be
+    /// careful.
+    fn unary(&mut self, _syntax: &syntax::Unary) -> Result<()> {
+        unimplemented!("operator compiling not yet implemented")
     }
 
     /// Compile a block expression.
@@ -234,7 +250,7 @@ impl Compiler {
     /// Compile a literal
     fn literal(&mut self, syntax: &syntax::Literal) -> Result<()> {
         match syntax.kind() {
-            syntax::LiteralKind::Binary => self.binary(syntax),
+            syntax::LiteralKind::Binary => self.binary_literal(syntax),
             syntax::LiteralKind::Bool => self.bool(syntax),
             syntax::LiteralKind::Char => self.char(syntax),
             syntax::LiteralKind::Decimal => self.decimal(syntax),
@@ -248,7 +264,7 @@ impl Compiler {
     }
 
     /// Compile an binary numeric literal
-    fn binary(&mut self, syntax: &syntax::Literal) -> Result<()> {
+    fn binary_literal(&mut self, syntax: &syntax::Literal) -> Result<()> {
         let n = Constant::parse_radix(syntax.body(), 2)?;
         let index = self.constants.insert(n)?;
         self.emit(Op::LoadConstant(index), syntax.span())

--- a/src/compiler/src/compiler/visitor.rs
+++ b/src/compiler/src/compiler/visitor.rs
@@ -132,17 +132,62 @@ impl Compiler {
     }
 
     /// Compile a binary operator expression.
-    fn binary(&mut self, _syntax: &syntax::Binary) -> Result<()> {
-        unimplemented!("operator compiling not yet implemented")
+    fn binary(&mut self, syntax: &syntax::Binary) -> Result<()> {
+        self.expression(syntax.left())?;
+        self.expression(syntax.right())?;
+
+        let op = match syntax.operator() {
+            // math
+            "+" => Ok(Op::Add),
+            "-" => Ok(Op::Sub),
+            "*" => Ok(Op::Mul),
+            "/" => Ok(Op::Div),
+            "^" => Ok(Op::Pow),
+            "%" => Ok(Op::Mod),
+            // bitwise
+            "&" => Ok(Op::BitAnd),
+            "|" => Ok(Op::BitOr),
+            "⊕" => Ok(Op::BitXOR),
+            "<<" => Ok(Op::SLL),
+            ">>" => Ok(Op::SRL),
+            ">>>" => Ok(Op::SRA),
+            // comparison
+            "==" => Ok(Op::Eq),
+            "!=" => Ok(Op::NEq),
+            ">" => Ok(Op::Gt),
+            ">=" => Ok(Op::GEq),
+            "<" => Ok(Op::Lt),
+            "<=" => Ok(Op::LEq),
+
+            _ => Err(Error::UndefinedInfix),
+        }?;
+
+        self.emit(op, syntax.operator_span())
     }
 
     /// Compile a unary operator expression.
     ///
     /// We want to evaluate left-to-right, and we're not sure if retrieving a
-    /// definition of an operator could have side effects, so we need to be
-    /// careful.
-    fn unary(&mut self, _syntax: &syntax::Unary) -> Result<()> {
-        unimplemented!("operator compiling not yet implemented")
+    /// definition of an operator could have side effects, so we'll need to be
+    /// careful when this is doing more than compiling to a single op code.
+    fn unary(&mut self, syntax: &syntax::Unary) -> Result<()> {
+        // This is mostly temporary until a real built-ins system is in place.
+        self.expression(syntax.operand())?;
+
+        let span = syntax.operator_span();
+        if syntax.is_prefix() {
+            match syntax.operator() {
+                "!" => self.emit(Op::Not, span),
+                "-" => self.emit(Op::Neg, span),
+                "+" => Ok(()),
+                _ => Err(Error::UndefinedPostfix),
+            }
+        } else {
+            match syntax.operator() {
+                // None defined, yet.
+                _ => Err(Error::UndefinedPostfix),
+            }
+        }
     }
 
     /// Compile a block expression.

--- a/src/compiler/src/error.rs
+++ b/src/compiler/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
 
     MutationNotSupported,
     UndefinedLocal,
+    UndefinedPrefix,
+    UndefinedInfix,
+    UndefinedPostfix,
 
     TooManyArguments,
     TooManyConstants,

--- a/src/compiler/src/opcode.rs
+++ b/src/compiler/src/opcode.rs
@@ -8,18 +8,25 @@ use crate::{
 
 /// These are the individual instructions that our VM interprets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[rustfmt::skip]
 pub enum Op {
-    /// Stop the program for good.
+    // ## VM control
+
+    /// Stop the program.
     Halt,
 
-    /// Stop but in a way where it could be resumed.
+    /// Stop the program, but in a way that signals an intent to restart it.
     Yield,
 
     /// Does nothing.
     Nop,
 
+    // ## Stack Manipulation
+
     /// Discard the value on the top of the stack, if there is one.
     Pop,
+
+    // ## Loading constant values
 
     /// Push a `true` to the top of the stack.
     True,
@@ -34,6 +41,8 @@ pub enum Op {
     /// stack. The currently executing module's constant pool is used.
     LoadConstant(Index<Constant>),
 
+    // ## Loading other kinds of values
+
     /// Load a local binding.
     LoadLocal(Index<Local>),
 
@@ -42,6 +51,8 @@ pub enum Op {
 
     /// Load a prototype and make a closure from it, placing it on the stack.
     LoadClosure(Index<Prototype>),
+
+    // ## Function Calls
 
     /// Call a closure on the stack.
     ///
@@ -52,6 +63,8 @@ pub enum Op {
     /// Return from the currently executing function.
     Return,
 
+    // ## Branching
+
     /// Jump to the given opcode index _in the current prototype_
     /// unconditionally.
     Jump(Index<Op>),
@@ -60,17 +73,99 @@ pub enum Op {
     /// stack if false.
     BranchFalse(Index<Op>),
 
+    // ## Logical Operators
+    //
+    // We don't have a logical `And` or `Or`, since these would normally be
+    // short-circuiting implementations which need branching.
+
+    /// Unary logical negation
+    Not,
+
+    // ## Math operators
+
+    /// Unary negation, `-n`
+    Neg,
+
+    /// Binary addition
+    Add,
+
+    /// Binary subtraction
+    Sub,
+
+    /// Binary multiplication
+    Mul,
+
+    /// Binary division
+    Div,
+
+    /// Binary Exponentiation
+    Pow,
+
+    /// Modulus, `n % 2`
+    Mod,
+
+    // ## Bitwise Operators
+
+    /// Bitwise And
+    BitAnd,
+
+    /// Bitwise Or
+    BitOr,
+
+    /// Bitwise Not
+    BitNot,
+
+    /// Bitwise XOR
+    BitXOR,
+
+    /// Shift Left (logical)
+    SLL,
+
+    /// Shift right logical
+    SRL,
+
+    /// Shift right arithmetic
+    SRA,
+
+    // ## Comparison Operators
+
+    /// Equals
+    Eq,
+
+    /// Not Equals
+    NEq,
+
+    /// Greater Than
+    Gt,
+
+    /// Greater than or equal to
+    GEq,
+
+    /// Less Than
+    Lt,
+
+    /// Less than or equal to
+    LEq,
+
+    // ## Temporary
+    //
+    // Until the 'real' implementation is done, 
+
     /// Make a list using the indicated number of arguments on the stack.
     List(u32),
+
 }
 
 impl Display for Op {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
+            // control
             Op::Halt => write!(f, "Halt"),
             Op::Yield => write!(f, "Yield"),
             Op::Nop => write!(f, "Nop"),
+            // stack
             Op::Pop => write!(f, "Pop"),
+            // values
             Op::True => write!(f, "True"),
             Op::False => write!(f, "False"),
             Op::Unit => write!(f, "Unit"),
@@ -78,11 +173,37 @@ impl Display for Op {
             Op::LoadLocal(i) => write!(f, "LoadLocal {}", i.as_u32()),
             Op::DefineLocal => write!(f, "DefineLocal"),
             Op::LoadClosure(i) => write!(f, "LoadClosure {}", i.as_u32()),
+            // functions
             Op::Call(i) => write!(f, "Call {}", i),
             Op::Return => write!(f, "Return"),
             Op::Jump(i) => write!(f, "Jump {}", i.as_u32()),
             Op::BranchFalse(i) => write!(f, "BranchFalse {}", i.as_u32()),
-
+            // logic
+            Op::Not => write!(f, "Not"),
+            // math
+            Op::Neg => write!(f, "Neg"),
+            Op::Add => write!(f, "Add"),
+            Op::Sub => write!(f, "Sub"),
+            Op::Mul => write!(f, "Mul"),
+            Op::Div => write!(f, "Div"),
+            Op::Pow => write!(f, "Pow"),
+            Op::Mod => write!(f, "Mod"),
+            // bitwise
+            Op::BitAnd => write!(f, "BitAnd"),
+            Op::BitOr => write!(f, "BitOr"),
+            Op::BitNot => write!(f, "BitNot"),
+            Op::BitXOR => write!(f, "BitXOR"),
+            Op::SLL => write!(f, "SLL"),
+            Op::SRL => write!(f, "SRL"),
+            Op::SRA => write!(f, "SRA"),
+            // comparison
+            Op::Eq => write!(f, "Eq"),
+            Op::NEq => write!(f, "NEq"),
+            Op::Gt => write!(f, "Gt"),
+            Op::GEq => write!(f, "GEq"),
+            Op::Lt => write!(f, "Lt"),
+            Op::LEq => write!(f, "LEq"),
+            // temporary
             Op::List(n) => write!(f, "List {n}"),
         }
     }

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -34,6 +34,8 @@ pub enum Error {
     InfixUnbalancedWhitespace,
     InfixWrongPrecedence,
 
+    MultipleNonAssociativeOperators,
+
     UnusedInput,
     LexerError(lexer::Error),
 }
@@ -86,11 +88,11 @@ impl fmt::Display for Error {
             PrefixNoSpaceBefore => write!(f, "Prefix operators must have whitespace before them"),
             PostfixNoSpaceAfter => write!(f, "Postfix operators must have whitespace after them"),
             PostfixSpaceBefore => write!(f, "Postfix operators cannot have whitespace before them"),
-            PostfixOperatorAtStartOfInput => write!(f, "Postfix operators cannot be at the start of the input."),
+            PostfixOperatorAtStartOfInput => write!(f, "Postfix operators cannot be at the start of the input"),
             InfixAtStartOrEnd => write!(f, "Infix operators must have code on either side"),
             InfixUnbalancedWhitespace => write!(f, "Infix operators must have balanced whitespace"),
-
-            InfixWrongPrecedence  => write!(f, "An infix operator was found, but not with the right precedence."),
+            InfixWrongPrecedence  => write!(f, "An infix operator was found, but not with the right precedence"),
+            MultipleNonAssociativeOperators => write!(f, "Multiple non-associative operators"),
 
             UnusedInput => write!(f, "There was unused input when parsing"),
             LexerError(e) => write!(f, "{}", e),

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -4,7 +4,10 @@ use std::{error, fmt};
 
 use crate::lexer::{self, TokenKind as Kind};
 
-/// Lexical errors with all the contextual information needed present it nicely.
+/// Parser errors
+///
+/// Later we'll add a way to build up more of the context we need for better
+/// diagnostics, but this is pretty incomplete for now.
 #[derive(Debug)]
 pub enum Error {
     ParserDepthExceeded,
@@ -15,6 +18,21 @@ pub enum Error {
     Unexpected { wanted: &'static str, found: Kind },
 
     KeywordNoSpace,
+
+    OperatorNotDefinedAsPrefix,
+    OperatorNotDefinedAsPostfix,
+    OperatorNotDefinedAsInfix,
+
+    PrefixSpaceAfter,
+    PrefixNoSpaceBefore,
+
+    PostfixNoSpaceAfter,
+    PostfixSpaceBefore,
+    PostfixOperatorAtStartOfInput,
+
+    InfixAtStartOrEnd,
+    InfixUnbalancedWhitespace,
+    InfixWrongPrecedence,
 
     UnusedInput,
     LexerError(lexer::Error),
@@ -60,6 +78,19 @@ impl fmt::Display for Error {
                 f,
                 "keyword literals must not have a space after the colon"
             ),
+
+            OperatorNotDefinedAsPrefix => write!(f, "Not a prefix operator"),
+            OperatorNotDefinedAsPostfix => write!(f, "Not a postfix operator"),
+            OperatorNotDefinedAsInfix => write!(f, "Not an infix operator"),
+            PrefixSpaceAfter => write!(f, "Prefix operators cannot have whitespace after them"),
+            PrefixNoSpaceBefore => write!(f, "Prefix operators must have whitespace before them"),
+            PostfixNoSpaceAfter => write!(f, "Postfix operators must have whitespace after them"),
+            PostfixSpaceBefore => write!(f, "Postfix operators cannot have whitespace before them"),
+            PostfixOperatorAtStartOfInput => write!(f, "Postfix operators cannot be at the start of the input."),
+            InfixAtStartOrEnd => write!(f, "Infix operators must have code on either side"),
+            InfixUnbalancedWhitespace => write!(f, "Infix operators must have balanced whitespace"),
+
+            InfixWrongPrecedence  => write!(f, "An infix operator was found, but not with the right precedence."),
 
             UnusedInput => write!(f, "There was unused input when parsing"),
             LexerError(e) => write!(f, "{}", e),

--- a/src/parser/src/lexer/mod.rs
+++ b/src/parser/src/lexer/mod.rs
@@ -6,10 +6,6 @@
 //! Before we can start the task of parsing, we need to sweep over the input and
 //! breaking it apart into meaningful atoms called [`Token`]s.
 //!
-//! Lexing can happen over `&str` when unicode validation should be done before
-//! hand. You can use [`verify_utf8`][crate::verify_utf8] to perform that
-//! validation if needed.
-//!
 //! # Notes
 //!
 //! You may be wondering why Lexer doesn't implement `Iterator`. The short

--- a/src/parser/src/lexer/rules.rs
+++ b/src/parser/src/lexer/rules.rs
@@ -204,5 +204,11 @@ fn is_operator(c: char) -> bool {
         && c != '"'
         && c != '\''
         && c != '_'
+        && c != '{'
+        && c != '('
+        && c != '['
+        && c != ']'
+        && c != ')'
+        && c != '}'
         && (c.is_symbol() || c.is_punctuation())
 }

--- a/src/parser/src/lexer/rules.rs
+++ b/src/parser/src/lexer/rules.rs
@@ -114,7 +114,6 @@ impl Lexer<'_> {
             "" => unreachable!(
                 "Lexer::operator should only be called after an operator start"
             ),
-            "=" => Ok(TokenKind::Equals),
             "->" => Ok(TokenKind::Arrow),
             "=>" => Ok(TokenKind::DoubleArrow),
             _ => Ok(TokenKind::Operator),

--- a/src/parser/src/lexer/token.rs
+++ b/src/parser/src/lexer/token.rs
@@ -76,8 +76,7 @@ pub enum Kind {
 
     /// Things like `foo` are identifies, names for things.
     Identifier,
-    /// Things like `+`, `==` or `>>=` are operators. Notably, a single `=` is
-    /// not.
+    /// Things like `+`, `==` or `>>=` are operators.
     Operator,
 
     /// `->` or `→`
@@ -92,8 +91,6 @@ pub enum Kind {
     Comma,
     /// `=>` or `⇒`
     DoubleArrow,
-    ///`=`
-    Equals,
     /// `;`
     Semicolon,
 
@@ -139,7 +136,6 @@ impl Kind {
             Colon => "colon (:)",
             Comma => "comma (,)",
             DoubleArrow => "double arrow (=>)",
-            Equals => "equals sign (=)",
             Semicolon => "semicolon (;)",
             Dot => "period (.)",
             Range => "range (..)",

--- a/src/parser/src/lexer/token.rs
+++ b/src/parser/src/lexer/token.rs
@@ -8,8 +8,7 @@
 
 use diagnostic::Span;
 
-/// An individual lexeme in our language, along with the surrounding whitespace,
-/// comments and location tracking information.
+/// An individual lexeme in our language.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Token<'a> {
     /// The semantic kind thing the token is. See `Kind` for more.

--- a/src/parser/src/lib.rs
+++ b/src/parser/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod error;
 pub mod lexer;
+pub mod operator;
 pub mod parser;
 
 pub use crate::{error::Error, parser::Parser};

--- a/src/parser/src/operator.rs
+++ b/src/parser/src/operator.rs
@@ -112,11 +112,11 @@ impl Fixity {
 /// A dictionary-like value for keeping track of which operators are defined,
 /// and what kind of use they support (of infix, prefix, and postfix).
 #[derive(Debug)]
-pub(crate) struct Operators {
+pub struct DefinedOperators {
     defined: HashMap<String, Fixity>,
 }
 
-impl Operators {
+impl DefinedOperators {
     /// Is a specific operator defined for prefix use?
     pub fn is_prefix(&self, op: &str) -> bool {
         self.defined.get(op).map(Fixity::prefix).unwrap_or(false)
@@ -145,9 +145,15 @@ impl Operators {
         old
     }
 
+    /// Is a specific operator defined for infix use at any precedence level and
+    /// associativity?
+    pub fn is_infix(&self, op: &str) -> bool {
+        self.get_infix(op).is_some()
+    }
+
     /// The precedence level and associativity for an operator, if it's defined
     /// for infix use. If it's not defined for infix, `None` is returned.
-    pub fn is_infix(&self, op: &str) -> Option<(Associativity, Precedence)> {
+    pub fn get_infix(&self, op: &str) -> Option<(Associativity, Precedence)> {
         self.defined.get(op).and_then(Fixity::infix)
     }
 
@@ -179,11 +185,11 @@ impl Operators {
     }
 }
 
-impl Default for Operators {
+impl Default for DefinedOperators {
     fn default() -> Self {
         use Associativity::*;
 
-        let mut op = Operators {
+        let mut op = DefinedOperators {
             defined: HashMap::default(),
         };
 

--- a/src/parser/src/operator.rs
+++ b/src/parser/src/operator.rs
@@ -1,0 +1,273 @@
+//! Operator fixity and precedence definitions.
+//!
+//! ## Precedence of infix and postfix operators
+//!
+//! Note that [`Precedence`] is only used with infix operators. Both pre- and
+//! post-fix operators always bind more tightly than infix, which is to say
+//! they're higher precedence. The ranking is as follows:
+//!
+//! 1. Any postfix operators
+//! 2. Any prefix operators
+//! 3. Infix operators, according to [`Precedence`]
+//!
+//! This isn't really _Truth_, it's just that other options lead to results that
+//! feel [surprising] compared to how were using to reading math.
+//!
+//! [surprising]: https://stackoverflow.com/questions/21973537/
+//!
+//! Allowing infix operators to have higher precedence that prefix would allow
+//! `•a ◊ b` to mean `•(a ◊ b)`, which most people wouldn't expect even though
+//! those symbols don't have any commonly understood meaning here.
+
+use std::collections::HashMap;
+
+/// The associativity of an operator.
+///
+/// Operators 'lean' to a side when multiple operators with the same precedence
+/// occur in a sequence. For example, addition is usually left-associative,
+/// which means that `a + b + c` is the same as `(a + b) + c`. Since the left
+/// one binds first, it's 'left' associative.
+///
+/// An example of a right-associative operator is the `->` used for functions
+/// types. A type like `a -> b -> c` is parsed as `a -> (b -> c)`, i.e. a
+/// function which returns a function.
+///
+/// You can also [Disallow][Associativity::Disallow] associativity for an
+/// operator. What this means is that operators of that precedence cannot be
+/// used in a context where the associativity would be needed determine the
+/// correct parse. This is useful for operators which are more about side
+/// effect, such as assignment, where the order may not be clear. For example,
+/// we don't want to allow multiple assignment, e.g. `a = b = c`.
+///
+/// Usually math operators are [`Left`][Associativity::Left] aligned. Examples
+/// of right-associative operators are exponentiation, or the `->` in function
+/// types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Associativity {
+    Left,
+    Right,
+    Disallow,
+}
+
+/// The precedence of an operator.
+///
+/// When multiple operators are used, precedence is how we decide which one
+/// 'happens first'. For example, `a + b * c` is read as the same as `a + (b *
+/// c)` because the `*` has higher precedence
+///
+/// This is really the same thing as PEDMAS but extended to more symbols.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct Precedence(u8);
+
+impl Precedence {
+    /// The highest possible precedence.
+    pub const MAX: Precedence = Precedence(16);
+
+    /// The lowest possible precedence.
+    pub const MIN: Precedence = Precedence(0);
+
+    /// The next higher precedence.
+    pub fn next(self) -> Self {
+        if self == Precedence::MAX {
+            panic!("Precedence overflow!");
+        }
+
+        Precedence(self.0 + 1)
+    }
+}
+
+/// Information about how an operator has been defined for use. Some operators
+/// can be used in different ways, such as `-a` and `a - b`. Some are even all
+/// three, such as [Rust's range expressions][range] `..`.
+///
+/// [range]: https://doc.rust-lang.org/reference/expressions/range-expr.html
+#[derive(Debug, Default, Clone, Copy)]
+struct Fixity {
+    prefix: bool,
+    postfix: bool,
+    infix: Option<(Associativity, Precedence)>,
+}
+
+impl Fixity {
+    /// Is the operator defined for use as prefix?
+    #[inline]
+    fn prefix(&self) -> bool {
+        self.prefix
+    }
+
+    /// Is the operator defined for use as postfix?
+    #[inline]
+    fn postfix(&self) -> bool {
+        self.postfix
+    }
+
+    /// Is the operator defined for use as postfix, and with what associativity
+    /// and precedence?
+    #[inline]
+    fn infix(&self) -> Option<(Associativity, Precedence)> {
+        self.infix
+    }
+}
+
+/// A dictionary-like value for keeping track of which operators are defined,
+/// and what kind of use they support (of infix, prefix, and postfix).
+#[derive(Debug)]
+pub(crate) struct Operators {
+    defined: HashMap<String, Fixity>,
+}
+
+impl Operators {
+    /// Is a specific operator defined for prefix use?
+    pub fn is_prefix(&self, op: &str) -> bool {
+        self.defined.get(op).map(Fixity::prefix).unwrap_or(false)
+    }
+
+    /// Define a new prefix operator. Returns whether the operator was already
+    /// defined for prefix use.
+    pub fn define_prefix(&mut self, op: &str) -> bool {
+        let fixity = self.get_mut(op);
+        let old = fixity.prefix;
+        fixity.prefix = true;
+        old
+    }
+
+    /// Is a specific operator defined for postfix use?
+    pub fn is_postfix(&self, op: &str) -> bool {
+        self.defined.get(op).map(Fixity::postfix).unwrap_or(false)
+    }
+
+    /// Define a new postfix operator. Returns whether the operator was already
+    /// defined for postfix use.
+    pub fn define_postfix(&mut self, op: &str) -> bool {
+        let fixity = self.get_mut(op);
+        let old = fixity.postfix;
+        fixity.postfix = true;
+        old
+    }
+
+    /// The precedence level and associativity for an operator, if it's defined
+    /// for infix use. If it's not defined for infix, `None` is returned.
+    pub fn is_infix(&self, op: &str) -> Option<(Associativity, Precedence)> {
+        self.defined.get(op).and_then(Fixity::infix)
+    }
+
+    /// Define a new infix operator using the given associativity and
+    /// precedence. If one was already defined it is returned, otherwise `None`
+    /// is returned.
+    pub fn define_infix(
+        &mut self,
+        op: &str,
+        associate: Associativity,
+        precedence: Precedence,
+    ) -> Option<(Associativity, Precedence)> {
+        let fixity = self.get_mut(op);
+        let old = fixity.infix;
+        fixity.infix = Some((associate, precedence));
+        old
+    }
+
+    /// Get a mutable reference fixity for an operator.
+    ///
+    /// This will creates an entry with the default not-defined-for-any-use
+    /// fixity if one doesn't already exist.
+    fn get_mut(&mut self, op: &str) -> &mut Fixity {
+        if !self.defined.contains_key(op) {
+            self.defined.insert(op.into(), Fixity::default());
+        }
+
+        self.defined.get_mut(op).unwrap()
+    }
+}
+
+impl Default for Operators {
+    fn default() -> Self {
+        use Associativity::*;
+
+        let mut op = Operators {
+            defined: HashMap::default(),
+        };
+
+        // the comments are what I've seen them used as, not what this language
+        // will necessarily use them as.
+
+        op.define_postfix("!"); // unwrap
+        op.define_postfix("?"); // try
+
+        op.define_prefix("!"); // not
+        op.define_prefix("+"); // positive
+        op.define_prefix("-"); // unary negative
+        op.define_prefix("~"); // not
+        op.define_prefix("*"); // deref,
+
+        // lets us move these around easier
+        let mut p = Precedence::MIN;
+
+        // exponentiation
+        op.define_infix("^", Right, p); // pow
+
+        // multiplication
+        p = p.next();
+        op.define_infix("*", Left, p); // mul
+        op.define_infix("/", Left, p); // div
+        op.define_infix("%", Left, p); // mod
+
+        // addition
+        p = p.next();
+        op.define_infix("+", Left, p); // add
+        op.define_infix("-", Left, p); // sub
+
+        // shifts
+        p = p.next();
+        op.define_infix("<<", Left, p); // sl
+        op.define_infix(">>", Left, p); // sr
+
+        // comparison
+        p = p.next();
+        op.define_infix("<", Left, p); // less
+        op.define_infix(">", Left, p); // greater
+        op.define_infix("<=", Left, p); // leq
+        op.define_infix(">=", Left, p); // geq
+        op.define_infix("<>", Left, p); // diamond
+        op.define_infix("><", Left, p); // duck
+
+        // equality
+        p = p.next();
+        op.define_infix("==", Left, p); // eq
+        op.define_infix("!=", Left, p); // neq
+
+        // bits
+        p = p.next();
+        op.define_infix("&", Left, p); // bit and
+        op.define_infix("|", Left, p); // bit or
+
+        // error
+        op.define_infix("??", Left, p); // coalescing
+
+        // errors and pipes
+        p = p.next();
+        op.define_infix("|>", Left, p); // f pipe
+
+        // functions
+        p = p.next();
+        op.define_infix("->", Right, p);
+
+        // assignment
+        p = p.next();
+        op.define_infix("=", Disallow, p);
+        op.define_infix("+=", Disallow, p);
+        op.define_infix("-=", Disallow, p);
+        op.define_infix("*=", Disallow, p);
+        op.define_infix("/=", Disallow, p);
+        op.define_infix("%=", Disallow, p);
+        op.define_infix("&=", Disallow, p);
+        op.define_infix("|=", Disallow, p);
+        op.define_infix("^=", Disallow, p);
+
+        op
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // nothing here is complicated enough to bother testing, yet.
+}

--- a/src/parser/src/operator.rs
+++ b/src/parser/src/operator.rs
@@ -222,11 +222,6 @@ impl Default for DefinedOperators {
         op.define_infix("+", Left, p); // add
         op.define_infix("-", Left, p); // sub
 
-        // shifts
-        p = p.next();
-        op.define_infix("<<", Left, p); // sl
-        op.define_infix(">>", Left, p); // sr
-
         // comparison
         p = p.next();
         op.define_infix("<", Left, p); // less
@@ -245,6 +240,12 @@ impl Default for DefinedOperators {
         p = p.next();
         op.define_infix("&", Left, p); // bit and
         op.define_infix("|", Left, p); // bit or
+
+        // shifts
+        p = p.next();
+        op.define_infix("<<", Left, p); // sll
+        op.define_infix(">>", Left, p); // srl
+        op.define_infix(">>>", Left, p); // sra
 
         // error
         op.define_infix("??", Left, p); // coalescing

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -7,6 +7,7 @@ use diagnostic::Span;
 use crate::{
     error::Error,
     lexer::{Lexer, Token, TokenKind},
+    operator::Operators,
     Parse,
 };
 
@@ -22,6 +23,9 @@ pub struct Parser<'a> {
     /// The grammar can be recursive in a few places, we track our 'depth' into
     /// these recursive forms here to prevent stack overflows.
     depth: usize,
+
+    /// The operators we know how to parse.
+    operators: Operators,
 }
 
 impl<'a> Parser<'a> {
@@ -45,6 +49,7 @@ impl<'a> Parser<'a> {
             cursor: 0,
             depth: 0,
             tokens,
+            operators: Operators::default(),
         })
     }
 

--- a/src/parser/src/parser/mod.rs
+++ b/src/parser/src/parser/mod.rs
@@ -1,17 +1,24 @@
-//! A parser.
+//! Parsers.
 //!
-//! This takes some input
+//! See the [module documentation][crate] for more information on how this all
+//! fits together, and how to use it.
+
+pub mod operator_parsing;
 
 use diagnostic::Span;
 
 use crate::{
     error::Error,
     lexer::{Lexer, Token, TokenKind},
-    operator::Operators,
+    operator::DefinedOperators,
     Parse,
 };
 
-/// A parser.
+/// A Parser wraps breaks input up into tokens and provides ways to work with
+/// that sequence of tokens to define a grammar using [`Parse`].
+///
+/// See the [module documentation][crate] for more information on how this all
+/// fits together, and how to use it.
 #[derive(Debug)]
 pub struct Parser<'a> {
     /// The tokens from our input.
@@ -25,7 +32,7 @@ pub struct Parser<'a> {
     depth: usize,
 
     /// The operators we know how to parse.
-    operators: Operators,
+    operators: DefinedOperators,
 }
 
 impl<'a> Parser<'a> {
@@ -49,12 +56,11 @@ impl<'a> Parser<'a> {
             cursor: 0,
             depth: 0,
             tokens,
-            operators: Operators::default(),
+            operators: DefinedOperators::default(),
         })
     }
 
-    /// Consume input to produce the specified piece of [`Parse`]able
-    /// [`Syntax`][crate::Syntax].
+    /// Consume input to produce the specified piece of [`Parse`]able syntax.
     ///
     /// # Note
     ///
@@ -338,6 +344,6 @@ mod parser_tests {
     // A few things are tested elsewhere since testing makes more sense with a
     // grammar specified. See tests in `/tests/parser_tests.rs` for more.
     //
-    // - `track_depth`
+    // - `depth_track`
     // - `sep_by_trailing`
 }

--- a/src/parser/src/parser/operator_parsing.rs
+++ b/src/parser/src/parser/operator_parsing.rs
@@ -1,0 +1,439 @@
+//! Operator Parsing
+//!
+//! These methods help us determine if an [`Operator`][TokenKind::Operator] is
+//! being used as prefix, postfix or infix.
+//!
+//! Ultimately, I want to support user-defined operators with user-defined
+//! precedence, while using the same operator in any of these positions.
+//!
+//! To make this work, we use whitespace around operators to tell us how an
+//! operator is being used. The full details are in the documentation below.
+//!
+//! ## Why whitespace?
+//!
+//! This is simplest way to do this that I can find, and the main side effect on
+//! the programmer is requiring nicer code formatting. It's also more or less
+//! [what Swift does][swift-lex], and it's surprisingly hard to find people
+//! complaining or confused by it.
+//!
+//! It does mean that an expression like `1+-7` that works in a languages like
+//! C, Python or Ruby, is instead parsed as the infix operator `+-` and won't
+//! work though. Conceivably we could check for splits like this when generating
+//! the full diagnostic messages. It's not something we want to do on the fly
+//! though, as the lexer doesn't know which operators are or are not in scope at
+//! any given moment. We could work around this by streaming tokens and feeding
+//! that information back, but that's [historically][c-lex] not been a great
+//! solution. It also would leave us with situation where say `•`, `•◊` and `◊•`
+//! are defined, and splitting the expression `a•◊•b` becomes ambiguous again
+//! anyway.
+//!
+//! It was tempting to write something that would allow `a •a` to be infix.
+//! However, I felt that order becomes unclear when you have `a• •a` - which of
+//! the `•` operators is the infix one? This isn't ambiguous unless `•` is
+//! defined for all 3 positions, but it's ambiguous _to the reader_. It's also
+//! not clear that the complexity to allow the user to _choose_ which is which
+//! would be useful.
+//!
+//! [swift-lex]: https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#ID418
+//! [c-lex]: https://en.wikipedia.org/wiki/Lexer_hack
+
+use crate::{
+    error::Error,
+    lexer::{Delimiter, Token, TokenKind},
+    operator::{Associativity, DefinedOperators, Precedence},
+    parser::Parser,
+};
+
+// These methods are long, but not too complicated. To disambiguate operators, a
+// lot of things have to be checked. To the control flow flatter we use early
+// returns as each condition is violated.
+impl Parser<'_> {
+    pub const ALLOWED_BEFORE_PREFIX: &'static [TokenKind] = {
+        use Delimiter::*;
+        use TokenKind::*;
+        &[
+            Open(Parenthesis),
+            Open(Brace),
+            Open(Brace),
+            Comma,
+            Colon,
+            Semicolon,
+            Dot,
+        ]
+    };
+
+    pub const ALLOWED_AFTER_POSTFIX: &'static [TokenKind] = {
+        use Delimiter::*;
+        use TokenKind::*;
+        &[
+            Close(Parenthesis),
+            Close(Brace),
+            Close(Brace),
+            Comma,
+            Colon,
+            Semicolon,
+            Dot,
+        ]
+    };
+
+    /// The currently defined operators.
+    pub fn defined_operators(&self) -> &DefinedOperators {
+        &self.operators
+    }
+
+    /// A mutable reference the defined operators, which can be used to add
+    /// definitions.
+    pub fn defined_operators_mut(&mut self) -> &mut DefinedOperators {
+        &mut self.operators
+    }
+
+    /// Consume the next token if it's a prefix operator.
+    ///
+    /// The next token is a prefix operator when:
+    ///
+    /// 1. There's another token after it. The input cannot end with a prefix
+    ///    operator, since it needs to bind to something.
+    ///
+    /// 2. The next token is an [`Operator`][TokenKind::Operator].
+    ///
+    /// 3. The operator is defined for use as prefix. See [`DefinedOperators`].
+    ///
+    /// 4. No whitespace occurs on the right of the operator.
+    ///
+    /// 5. If there's a token before the operator, there's either whitespace
+    ///    between them, or the token is in [`Parser::ALLOWED_BEFORE_PREFIX`].
+    pub fn consume_prefix(&mut self) -> Result<Token, Error> {
+        const WANTED: &str = "a prefix operator";
+
+        // 1
+        if self.cursor + 1 >= self.tokens.len() {
+            return Err(Error::EOFExpecting(
+                "something following a prefix operator",
+            ));
+        }
+
+        // 2
+        let token = self.tokens[self.cursor];
+        if token.kind() != TokenKind::Operator {
+            return Err(Error::Unexpected {
+                wanted: WANTED,
+                found: token.kind(),
+            });
+        }
+
+        // 3
+        if !self.operators.is_prefix(token.body()) {
+            return Err(Error::OperatorNotDefinedAsPrefix);
+        }
+
+        // 4
+        let after_tok = self.tokens[self.cursor + 1];
+        let space_after = token.span().end() != after_tok.span().start();
+
+        if space_after {
+            return Err(Error::PrefixSpaceAfter);
+        }
+
+        // 5
+        if self.cursor > 0 {
+            let before_token = self.tokens[self.cursor - 1];
+            let space_before =
+                before_token.span().end() != token.span().start();
+            let is_allowed =
+                Parser::ALLOWED_BEFORE_PREFIX.contains(&before_token.kind());
+
+            if space_before || is_allowed {
+                return Err(Error::PrefixNoSpaceBefore);
+            }
+        }
+
+        self.consume(token.kind(), "a prefix operator")
+    }
+
+    /// Consume the next token if it's a postfix operator.
+    ///
+    /// It's a postfix operator when:
+    ///
+    /// 1. There's at least one token before it. It can't bind to nothing
+    ///
+    /// 2. The next token is an [`Operator`][TokenKind::Operator].
+    ///
+    /// 3. The operator is defined for postfix use. See [`DefinedOperators`].
+    ///
+    /// 4. No whitespace occurs on the left, otherwise it would be infix.
+    ///
+    /// 5. If there's a token after, there must be whitespace between them, or
+    ///    the token must be in [`Parser::ALLOWED_AFTER_POSTFIX`].
+    pub fn consume_postfix(&mut self) -> Result<Token, Error> {
+        const WANTED: &str = "a postfix operator";
+
+        // 1
+        if self.cursor == 0 {
+            return Err(Error::PostfixOperatorAtStartOfInput);
+        }
+
+        // 2
+        let token = self.tokens[self.cursor];
+        if token.kind() != TokenKind::Operator {
+            return Err(Error::Unexpected {
+                wanted: WANTED,
+                found: token.kind(),
+            });
+        }
+
+        // 3
+        if !self.operators.is_postfix(token.body()) {
+            return Err(Error::OperatorNotDefinedAsPostfix);
+        }
+
+        // 4
+        let before_token = self.tokens[self.cursor - 1];
+        let space_before = before_token.span().end() != token.span().start();
+
+        if space_before {
+            return Err(Error::PostfixNoSpaceAfter);
+        }
+
+        // 5
+        if self.cursor + 1 < self.tokens.len() {
+            let after_token = self.tokens[self.cursor + 1];
+            let space_after = token.span().end() != after_token.span().start();
+            let is_allowed =
+                Parser::ALLOWED_AFTER_POSTFIX.contains(&before_token.kind());
+
+            if space_after || is_allowed {
+                return Err(Error::PrefixNoSpaceBefore);
+            }
+        }
+
+        self.consume(token.kind(), WANTED)
+    }
+
+    /// Consume the next token iff it looks to be an infix operator, i.e. if the
+    /// following conditions are met:
+    ///
+    /// 1. We need at least 1 token before for the lhs, and 2 after for the
+    ///    operator we'll return and the rhs.
+    ///
+    /// 2. The next token is an `Kind::Operator`.
+    ///
+    /// 3. The operator is defined for use as an infix operator. This step is
+    ///    needed to determine precedence.
+    ///
+    /// 4. If the infix operator has precedence (i.e. associativity isn't
+    ///    explicitly disallowed for it, like with operators like `+=`) this
+    ///    precedence is equal to the argument `precedence`.
+    ///
+    /// 5. Whitespace is balanced -- there's either whitespace on both sides or
+    ///    on neither. This is a trick we're pulling from Swift to distinguish
+    ///    prefix and postfix from infix.
+    pub fn consume_infix(
+        &mut self,
+        wanted: Precedence,
+    ) -> Result<(Token, Associativity), Error> {
+        const WANTED: &str = "a prefix operator";
+
+        // 1
+        // if self.cursor == 0 || (self.cursor + 2 >= self.tokens.len()) {
+        if !(self.cursor >= 1 && self.cursor + 2 <= self.tokens.len()) {
+            return Err(Error::InfixAtStartOrEnd);
+        }
+
+        // 2
+        let token = self.tokens[self.cursor];
+        if token.kind() != TokenKind::Operator {
+            return Err(Error::Unexpected {
+                wanted: WANTED,
+                found: token.kind(),
+            });
+        }
+
+        // 3
+        let (associativity, found) = self
+            .operators
+            .get_infix(token.body())
+            .ok_or(Error::OperatorNotDefinedAsInfix)?;
+
+        // 4
+        if found != wanted {
+            return Err(Error::InfixWrongPrecedence);
+        }
+
+        // 5
+        let before_tok = self.tokens[self.cursor - 1];
+        let after_tok = self.tokens[self.cursor + 1];
+
+        let space_before = before_tok.span().end() != token.span().start();
+        let space_after = token.span().end() != after_tok.span().start();
+
+        if space_before != space_after {
+            return Err(Error::InfixUnbalancedWhitespace);
+        }
+
+        self.consume(token.kind(), WANTED)
+            .map(|t| (t, associativity))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::operator::DefinedOperators;
+
+    use super::*;
+
+    /// A helper to get the precedence of an operator in [`DefinedOperators`]
+    /// [`Default`]s.
+    fn prec_of(s: &str) -> Precedence {
+        DefinedOperators::default().get_infix(s).unwrap().1
+    }
+
+    #[test]
+    fn defined_operator_assumptions() {
+        // In our tests, we'll be using some operators to test things, and we
+        // need to make sure they're defined the way we think they are.
+        let parser = Parser::new("").unwrap();
+
+        assert!(parser.operators.is_prefix("-"));
+        assert!(parser.operators.is_postfix("?"));
+        assert!(parser.operators.get_infix("+").is_some());
+        assert_ne!(prec_of("*"), prec_of("+"))
+    }
+
+    #[test]
+    fn prefix() {
+        let mut parser = Parser::new("-a").unwrap();
+        assert!(parser.consume_prefix().is_ok());
+    }
+
+    #[test]
+    fn prefix_at_eof() {
+        let mut parser = Parser::new("-").unwrap();
+        assert!(parser.consume_prefix().is_err());
+    }
+
+    #[test]
+    fn prefix_with_space() {
+        let mut parser = Parser::new("- a").unwrap();
+        assert!(parser.consume_prefix().is_err());
+    }
+
+    #[test]
+    fn prefix_missing_space() {
+        let mut parser = Parser::new("a-a").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.consume_prefix().is_ok());
+    }
+
+    #[test]
+    fn prefix_missing_space_okay() {
+        let mut parser = Parser::new("(-a)").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "(").is_ok());
+        assert!(parser.consume_prefix().is_ok());
+    }
+
+    #[test]
+    fn postfix() {
+        let mut parser = Parser::new("a?").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.consume_postfix().is_ok());
+    }
+
+    #[test]
+    fn postfix_at_start() {
+        let mut parser = Parser::new("?a").unwrap();
+        assert!(parser.consume_postfix().is_err());
+    }
+
+    #[test]
+    fn postfix_with_space() {
+        let mut parser = Parser::new("a ?").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.consume_postfix().is_err());
+    }
+
+    #[test]
+    fn postfix_with_dot() {
+        let mut parser = Parser::new("a?.b").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.consume_postfix().is_ok());
+        assert!(parser.consume(TokenKind::Dot, ".").is_ok());
+    }
+
+    #[test]
+    fn postfix_with_other() {
+        let mut parser = Parser::new("a?[b]").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.consume_postfix().is_ok());
+    }
+
+    #[test]
+    fn infix() {
+        let mut parser = Parser::new("a + a").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.consume_infix(prec_of("+")).is_ok());
+    }
+
+    #[test]
+    fn infix_wrong_precedence() {
+        let mut parser = Parser::new("a + a").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.consume_infix(prec_of("*")).is_err());
+    }
+
+    #[test]
+    fn infix_no_spaces() {
+        let mut parser = Parser::new("a+a").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.consume_infix(prec_of("+")).is_ok());
+    }
+
+    #[test]
+    fn infix_unbalanced_left() {
+        let mut parser = Parser::new("a+ a").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.consume_infix(prec_of("+")).is_err());
+    }
+
+    #[test]
+    fn infix_unbalanced_right() {
+        let mut parser = Parser::new("a +a").unwrap();
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.consume_infix(prec_of("+")).is_err());
+    }
+
+    #[test]
+    fn all_three() {
+        let dot_prec = prec_of("+");
+        let wrong_prec = prec_of("*");
+
+        let mut parser = Parser::new("a• • •a").unwrap();
+
+        parser.defined_operators_mut().define_prefix("•");
+        parser.defined_operators_mut().define_postfix("•");
+        parser.defined_operators_mut().define_infix(
+            "•",
+            Associativity::Left,
+            dot_prec,
+        );
+
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+
+        assert!(parser.consume_prefix().is_err());
+        assert!(parser.consume_infix(wrong_prec).is_err());
+        assert!(parser.consume_infix(dot_prec).is_err());
+        assert!(parser.consume_postfix().is_ok());
+
+        assert!(parser.consume_prefix().is_err());
+        assert!(parser.consume_postfix().is_err());
+        assert!(parser.consume_infix(wrong_prec).is_err());
+        assert!(parser.consume_infix(dot_prec).is_ok());
+
+        assert!(parser.consume_postfix().is_err());
+        assert!(parser.consume_infix(wrong_prec).is_err());
+        assert!(parser.consume_infix(dot_prec).is_err());
+        assert!(parser.consume_prefix().is_ok());
+
+        assert!(parser.consume(TokenKind::Identifier, "a").is_ok());
+        assert!(parser.is_empty());
+    }
+}

--- a/src/parser/src/parser/operator_parsing.rs
+++ b/src/parser/src/parser/operator_parsing.rs
@@ -47,7 +47,7 @@ use crate::{
 // These methods are long, but not too complicated. To disambiguate operators, a
 // lot of things have to be checked. To the control flow flatter we use early
 // returns as each condition is violated.
-impl Parser<'_> {
+impl<'a> Parser<'a> {
     pub const ALLOWED_BEFORE_PREFIX: &'static [TokenKind] = {
         use Delimiter::*;
         use TokenKind::*;
@@ -105,7 +105,7 @@ impl Parser<'_> {
     ///
     /// 5. If there's a token before the operator, there's either whitespace
     ///    between them, or the token is in [`Parser::ALLOWED_BEFORE_PREFIX`].
-    pub fn consume_prefix(&mut self) -> Result<Token, Error> {
+    pub fn consume_prefix(&mut self) -> Result<Token<'a>, Error> {
         const WANTED: &str = "a prefix operator";
 
         // 1
@@ -167,7 +167,7 @@ impl Parser<'_> {
     ///
     /// 5. If there's a token after, there must be whitespace between them, or
     ///    the token must be in [`Parser::ALLOWED_AFTER_POSTFIX`].
-    pub fn consume_postfix(&mut self) -> Result<Token, Error> {
+    pub fn consume_postfix(&mut self) -> Result<Token<'a>, Error> {
         const WANTED: &str = "a postfix operator";
 
         // 1
@@ -232,7 +232,7 @@ impl Parser<'_> {
     pub fn consume_infix(
         &mut self,
         wanted: Precedence,
-    ) -> Result<(Token, Associativity), Error> {
+    ) -> Result<(Token<'a>, Associativity), Error> {
         const WANTED: &str = "a prefix operator";
 
         // 1

--- a/src/parser/tests/lexer_tests.rs
+++ b/src/parser/tests/lexer_tests.rs
@@ -55,7 +55,7 @@ fn lexer_punctuation() {
     );
     assert_eq!(lexer.token().unwrap().kind(), TokenKind::Comma);
     assert_eq!(lexer.token().unwrap().kind(), TokenKind::Dot);
-    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Equals);
+    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Operator);
     assert_eq!(lexer.token().unwrap().kind(), TokenKind::DoubleArrow);
     assert_eq!(lexer.token().unwrap().kind(), TokenKind::Operator);
 }
@@ -152,7 +152,7 @@ fn unicode_identifier() {
         TokenKind::Reserved(Reserved::Let)
     );
     assert_eq!(lexer.token().unwrap().kind(), TokenKind::Identifier);
-    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Equals);
+    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Operator);
     assert_eq!(lexer.token().unwrap().kind(), TokenKind::Identifier);
     assert_eq!(lexer.token().unwrap().kind(), TokenKind::Semicolon);
     assert!(lexer.is_empty());

--- a/src/parser/tests/lexer_tests.rs
+++ b/src/parser/tests/lexer_tests.rs
@@ -85,6 +85,15 @@ fn lexer_operator_intuition() {
 }
 
 #[test]
+fn lexer_operator_chaining() {
+    let mut lexer = Lexer::new("a?.b");
+    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Identifier);
+    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Operator);
+    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Dot);
+    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Identifier);
+}
+
+#[test]
 fn comments_no_newline() {
     let mut lexer = Lexer::new("// comment");
     assert!(matches!(

--- a/src/parser/tests/lexer_tests.rs
+++ b/src/parser/tests/lexer_tests.rs
@@ -94,6 +94,18 @@ fn lexer_operator_chaining() {
 }
 
 #[test]
+fn lexer_operator_chaining_bracket() {
+    let mut lexer = Lexer::new("a?[b");
+    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Identifier);
+    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Operator);
+    assert_eq!(
+        lexer.token().unwrap().kind(),
+        TokenKind::Open(Delimiter::Bracket)
+    );
+    assert_eq!(lexer.token().unwrap().kind(), TokenKind::Identifier);
+}
+
+#[test]
 fn comments_no_newline() {
     let mut lexer = Lexer::new("// comment");
     assert!(matches!(

--- a/src/runtime/src/machine.rs
+++ b/src/runtime/src/machine.rs
@@ -28,30 +28,54 @@ impl Runtime {
             let op = self.fetch()?;
 
             match op {
+                // control
                 Op::Halt => return Ok(Exit::Halt),
                 Op::Yield => return Ok(Exit::Yield),
-
                 Op::Nop => continue,
+                // stack
                 Op::Pop => {
                     self.stack.pop();
                 }
-
+                // values
                 Op::True => self.stack.push(Value::TRUE),
                 Op::False => self.stack.push(Value::FALSE),
                 Op::Unit => self.stack.push(Value::UNIT),
-
                 Op::LoadConstant(i) => self.load_constant(i)?,
                 Op::LoadLocal(i) => self.load_local(i)?,
                 Op::LoadClosure(i) => self.load_closure(i)?,
-
                 Op::DefineLocal => self.define_local()?,
-
+                // functions
                 Op::Call(arg_count) => self.call(arg_count)?,
                 Op::Return => self.return_op()?,
-
+                // branching
                 Op::Jump(i) => self.jump(i)?,
                 Op::BranchFalse(i) => self.branch_false(i)?,
-
+                // logic
+                Op::Not => todo!(),
+                // math
+                Op::Neg => todo!(),
+                Op::Add => todo!(),
+                Op::Sub => todo!(),
+                Op::Mul => todo!(),
+                Op::Div => todo!(),
+                Op::Pow => todo!(),
+                Op::Mod => todo!(),
+                // bitwise
+                Op::BitAnd => todo!(),
+                Op::BitOr => todo!(),
+                Op::BitNot => todo!(),
+                Op::BitXOR => todo!(),
+                Op::SLL => todo!(),
+                Op::SRL => todo!(),
+                Op::SRA => todo!(),
+                // comparison
+                Op::Eq => todo!(),
+                Op::NEq => todo!(),
+                Op::Gt => todo!(),
+                Op::GEq => todo!(),
+                Op::Lt => todo!(),
+                Op::LEq => todo!(),
+                // temporary
                 Op::List(n) => self.list(n)?,
             }
         }

--- a/src/syntax/src/binding.rs
+++ b/src/syntax/src/binding.rs
@@ -63,11 +63,28 @@ impl<'a> Parse<'a> for Binding<'a> {
             "a `let` or `var`",
         )?;
 
+        let name = parser.parse()?;
+
+        let equals = parser.consume(Kind::Operator, "equals sign").and_then(
+            |token| {
+                if token.body() == "=" {
+                    Ok(token)
+                } else {
+                    Err(Error::Unexpected {
+                        wanted: "an equals sign",
+                        found: token.kind(),
+                    })
+                }
+            },
+        )?;
+
+        let body = parser.parse()?;
+
         Ok(Binding {
             keyword,
-            name: parser.parse()?,
-            equals: parser.consume(Kind::Equals, "an equals sign")?,
-            body: parser.parse()?,
+            name,
+            equals,
+            body,
         })
     }
 }

--- a/src/syntax/src/expression.rs
+++ b/src/syntax/src/expression.rs
@@ -2,6 +2,7 @@
 
 use parser::{
     lexer::{Delimiter, Reserved, TokenKind},
+    operator::Precedence,
     Parse,
 };
 
@@ -14,6 +15,7 @@ use super::*;
 /// [syn-crate]: https://docs.rs/syn/1.0.84/syn/enum.Expr.html#syntax-tree-enums
 #[derive(Debug)]
 pub enum Expression<'a> {
+    Binary(Binary<'a>),
     Block(Block<'a>),
     Call(Call<'a>),
     Function(Function<'a>),
@@ -22,6 +24,7 @@ pub enum Expression<'a> {
     If(IfElse<'a>),
     List(List<'a>),
     Literal(Literal<'a>),
+    Unary(Unary<'a>),
 }
 
 impl<'a> Syntax for Expression<'a> {
@@ -29,6 +32,7 @@ impl<'a> Syntax for Expression<'a> {
 
     fn span(&self) -> Span {
         match self {
+            Expression::Binary(b) => b.span(),
             Expression::Block(b) => b.span(),
             Expression::Call(c) => c.span(),
             Expression::Function(f) => f.span(),
@@ -37,6 +41,7 @@ impl<'a> Syntax for Expression<'a> {
             Expression::If(i) => i.span(),
             Expression::List(l) => l.span(),
             Expression::Literal(e) => e.span(),
+            Expression::Unary(u) => u.span(),
         }
     }
 }
@@ -45,11 +50,108 @@ impl<'a> Parse<'a> for Expression<'a> {
     fn parse_with(parser: &mut Parser<'a>) -> Result<Expression<'a>, Error> {
         // TODO: When we have operators, here's where we'll being precedence
         //       climbing, ending with `base`.
-        Expression::base(parser)
+        parser.depth_track(|parser| Expression::infix(parser, Precedence::MIN))
     }
 }
 
 impl<'a> Expression<'a> {
+    /// Parse an expression followed by zero or more infix operators of the
+    /// given precedence.
+    ///
+    /// # Grammar
+    ///
+    /// infix(max) := prefix
+    /// infix(n)   := infix(n+1) (consume_infix(n) (infix(n+1)))*
+    ///
+    /// What this means is the highest precedence level
+    ///
+    /// # How this works
+    ///
+    /// Honestly, I have no idea. I'm not even sure that it does.
+    fn infix(
+        parser: &mut Parser<'a>,
+        precedence: Precedence,
+    ) -> Result<Expression<'a>, Error> {
+        if precedence == Precedence::MAX {
+            return Expression::prefix(parser);
+        }
+
+        let mut lhs = Expression::infix(parser, precedence.next())?;
+        let mut non_associative_operator_seen = false;
+
+        while let Ok((token, associativity)) = parser.consume_infix(precedence)
+        {
+            let rhs = match associativity {
+                parser::operator::Associativity::Left => {
+                    Expression::infix(parser, precedence.next())
+                }
+                parser::operator::Associativity::Right => {
+                    Expression::infix(parser, precedence)
+                }
+                parser::operator::Associativity::Disallow => {
+                    if non_associative_operator_seen {
+                        return Err(Error::MultipleNonAssociativeOperators);
+                    } else {
+                        non_associative_operator_seen = true;
+                        Expression::infix(parser, precedence.next())
+                    }
+                }
+            }?;
+
+            lhs = Expression::Binary(Binary::new(token, lhs, rhs))
+        }
+
+        Ok(lhs)
+    }
+
+    /// Parse a prefix operator expression.
+    ///
+    /// # Grammar
+    ///
+    /// Prefix := prefix_operator Prefix
+    /// Prefix := base
+    fn prefix(parser: &mut Parser<'a>) -> Result<Expression<'a>, Error> {
+        parser.depth_track(|parser| {
+            if let Ok(token) = parser.consume_prefix() {
+                let expression = Expression::prefix(parser)?;
+                Ok(Expression::Unary(Unary::new_prefix(token, expression)))
+            } else {
+                Expression::postfix(parser)
+            }
+        })
+    }
+
+    /// Postfix expressions are primary expressions with
+    ///
+    /// # Grammar
+    ///
+    /// Postfix := primary | Call | PostfixOperator
+    pub(crate) fn postfix(
+        parser: &mut Parser<'a>,
+    ) -> Result<Expression<'a>, Error> {
+        let mut expression = Expression::primary(parser)?;
+
+        loop {
+            expression = match parser.peek() {
+                Some(TokenKind::Open(Delimiter::Parenthesis)) => {
+                    Call::parse_from(expression, parser)
+                        .map(Expression::Call)?
+                }
+                Some(TokenKind::Operator) => {
+                    if let Ok(op) = parser.consume_postfix() {
+                        Expression::Unary(Unary::new_postfix(op, expression))
+                    } else {
+                        break;
+                    }
+                }
+
+                _ => break,
+            }
+        }
+
+        Ok(expression)
+    }
+
     /// Primary expressions are expressions which don't themselves have any
     /// suffix parts or operators (i.e. no left or right recursion on expression).
     ///
@@ -59,58 +161,37 @@ impl<'a> Expression<'a> {
     pub(crate) fn primary(
         parser: &mut Parser<'a>,
     ) -> Result<Expression<'a>, Error> {
-        parser.depth_track(|parser| {
-            match parser.peek() {
-                Some(TokenKind::Reserved(Reserved::If)) => {
-                    parser.parse().map(Expression::If)
-                }
-
-                Some(TokenKind::Identifier) => {
-                    parser.parse().map(Expression::Identifier)
-                }
-
-                Some(TokenKind::Open(Delimiter::Brace)) => {
-                    // We'll need to do some backtracking here in the future to
-                    // decide if it's a block or record literal.
-                    parser.parse().map(Expression::Block)
-                }
-
-                Some(TokenKind::Open(Delimiter::Parenthesis)) => {
-                    Expression::open_parenthesis(parser)
-                }
-
-                Some(TokenKind::Open(Delimiter::Bracket)) => {
-                    parser.parse().map(Expression::List)
-                }
-
-                Some(k) if k.is_literal() || k == TokenKind::Colon => {
-                    parser.parse().map(Expression::Literal)
-                }
-
-                Some(_) => Err(Error::NotStartOf(Self::NAME)),
-
-                None => Err(Error::EOFExpecting(Self::NAME)),
+        match parser.peek() {
+            Some(TokenKind::Reserved(Reserved::If)) => {
+                parser.parse().map(Expression::If)
             }
-        })
-    }
 
-    /// Base expressions might have suffixes but don't have any operators.
-    ///
-    /// # Grammar
-    ///
-    /// base := primary | Call
-    pub(crate) fn base(
-        parser: &mut Parser<'a>,
-    ) -> Result<Expression<'a>, Error> {
-        let mut primary = Expression::primary(parser)?;
+            Some(TokenKind::Identifier) => {
+                parser.parse().map(Expression::Identifier)
+            }
 
-        while let Some(TokenKind::Open(Delimiter::Parenthesis)) = parser.peek()
-        {
-            primary =
-                Call::parse_from(primary, parser).map(Expression::Call)?;
+            Some(TokenKind::Open(Delimiter::Brace)) => {
+                // We'll need to do some backtracking here in the future to
+                // decide if it's a block or record literal.
+                parser.parse().map(Expression::Block)
+            }
+
+            Some(TokenKind::Open(Delimiter::Parenthesis)) => {
+                Expression::open_parenthesis(parser)
+            }
+
+            Some(TokenKind::Open(Delimiter::Bracket)) => {
+                parser.parse().map(Expression::List)
+            }
+
+            Some(k) if k.is_literal() || k == TokenKind::Colon => {
+                parser.parse().map(Expression::Literal)
+            }
+
+            Some(_) => Err(Error::NotStartOf(Self::NAME)),
+
+            None => Err(Error::EOFExpecting(Self::NAME)),
         }
-
-        Ok(primary)
     }
 
     /// Parse an expression which starts with an open paren.
@@ -152,6 +233,8 @@ impl<'a> Expression<'a> {
 
 #[cfg(test)]
 mod parser_tests {
+
+    use parser::operator::Associativity;
 
     use super::*;
 
@@ -258,5 +341,138 @@ mod parser_tests {
         let mut parser = Parser::new("if true {}").unwrap();
         let result = parser.parse::<Expression>();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn operator_test_assumptions() {
+        // make sure some operators are defined the way the following tests
+        // think they are.
+
+        let parser = Parser::new("").unwrap();
+        assert!(parser.defined_operators().is_prefix("-"));
+        assert!(parser.defined_operators().is_postfix("?"));
+
+        let (add_assoc, add_prec) =
+            parser.defined_operators().get_infix("+").unwrap();
+        let (_mul_assoc, mul_prec) =
+            parser.defined_operators().get_infix("*").unwrap();
+        let (arrow_assoc, _arrow_prec) =
+            parser.defined_operators().get_infix("->").unwrap();
+        let (eq_assoc, _eq_prec) =
+            parser.defined_operators().get_infix("=").unwrap();
+
+        assert!(add_prec > mul_prec);
+        assert_eq!(add_assoc, Associativity::Left);
+        assert_eq!(arrow_assoc, Associativity::Right);
+        assert_eq!(eq_assoc, Associativity::Disallow);
+    }
+
+    #[test]
+    fn prefix_operator() {
+        let mut parser = Parser::new("-1").unwrap();
+        let result = parser.parse::<Expression>();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn postfix_operator() {
+        let mut parser = Parser::new("1?").unwrap();
+        let result = parser.parse::<Expression>();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn infix_simple() {
+        let mut parser = Parser::new("1 + 2").unwrap();
+        let result = parser.parse::<Expression>();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn infix_with_unary_operators() {
+        let mut parser = Parser::new("-1? + -2?").unwrap();
+        let result = parser.parse::<Expression>();
+        assert!(
+            matches!(result, Ok(Expression::Binary(_))),
+            "got {:#?}",
+            result
+        )
+    }
+
+    #[test]
+    fn infix_left_associate() {
+        let mut parser = Parser::new("1 + 2 + 3").unwrap();
+        let result = parser.parse::<Expression>();
+        assert!(
+            matches!(result, Ok(Expression::Binary(ref b)) if matches!(b.left(), Expression::Binary(_))),
+            "got {:#?}",
+            result
+        )
+    }
+
+    #[test]
+    fn infix_right_associate() {
+        let mut parser = Parser::new("2^3^4").unwrap();
+        let result = parser.parse::<Expression>();
+        assert!(
+            matches!(result, Ok(Expression::Binary(ref b)) if matches!(b.right(), Expression::Binary(_))),
+            "got {:#?}",
+            result
+        )
+    }
+
+    #[test]
+    fn infix_precedence_higher_right() {
+        let mut parser = Parser::new("1 + 2 * 3").unwrap();
+        let result = parser.parse::<Expression>();
+        assert!(
+            matches!(result, Ok(Expression::Binary(ref b)) if b.operator() == "*"),
+            "got {:#?}",
+            result
+        )
+    }
+
+    #[test]
+    fn infix_precedence_higher_left() {
+        let mut parser = Parser::new("1 * 2 + 3").unwrap();
+        let result = parser.parse::<Expression>();
+        assert!(
+            matches!(result, Ok(Expression::Binary(ref b)) if b.operator() == "*"),
+            "got {:#?}",
+            result
+        )
+    }
+
+    #[test]
+    fn infix_non_associative() {
+        let mut parser = Parser::new("1 = 2 = 3").unwrap();
+        let result = parser.parse::<Expression>();
+        assert!(result.is_err(), "expected error but got {:#?}", result)
+    }
+
+    #[test]
+    fn infix_non_associative_different_precedences() {
+        let mut parser = Parser::new("1 <*> 2 <+> 3").unwrap();
+
+        let add_prec = parser.defined_operators().get_infix("+").unwrap().1;
+        let mul_prec = parser.defined_operators().get_infix("*").unwrap().1;
+
+        parser.defined_operators_mut().define_infix(
+            "<*>",
+            Associativity::Disallow,
+            mul_prec,
+        );
+        parser.defined_operators_mut().define_infix(
+            "<+>",
+            Associativity::Disallow,
+            add_prec,
+        );
+
+        let result = parser.parse::<Expression>();
+        assert!(
+            matches!(result, Ok(Expression::Binary(ref b)) if b.operator() == "<*>"),
+            "got {:#?}",
+            result
+        )
     }
 }

--- a/src/syntax/src/lib.rs
+++ b/src/syntax/src/lib.rs
@@ -17,6 +17,7 @@ mod grouping;
 mod ident;
 mod list;
 mod literal;
+mod operator;
 mod statement;
 
 pub use self::{
@@ -31,6 +32,7 @@ pub use self::{
     ident::Identifier,
     list::List,
     literal::{Kind as LiteralKind, Literal},
+    operator::{Binary, Unary},
     statement::{Statement, StatementSequence},
 };
 

--- a/src/syntax/src/operator.rs
+++ b/src/syntax/src/operator.rs
@@ -1,0 +1,104 @@
+//! Operator syntax nodes.
+//!
+//! Notable, these do not implement [`Parse`].
+//!
+//! [`Unary`] would need to understand primary and base expressions for things
+//! like `-a.?b!`, and [`Binary`] would need to know at what precedence. Both
+//! are so intertwined with [`Expression`], it doesn't really make sense to
+//! parse them outside of that context.
+
+use diagnostic::Span;
+
+use parser::lexer::Token;
+
+use crate::{Expression, Syntax};
+
+#[derive(Debug)]
+pub struct Unary<'a> {
+    token: Token<'a>,
+    is_prefix: bool,
+    operand: Box<Expression<'a>>,
+}
+
+impl<'a> Unary<'a> {
+    pub fn new_prefix(token: Token<'a>, operand: Expression<'a>) -> Unary<'a> {
+        Unary {
+            token,
+            operand: Box::new(operand),
+            is_prefix: true,
+        }
+    }
+
+    pub fn new_postfix(token: Token<'a>, operand: Expression<'a>) -> Unary<'a> {
+        Unary {
+            token,
+            operand: Box::new(operand),
+            is_prefix: false,
+        }
+    }
+
+    /// The body of the operator token.
+    pub fn operator(&self) -> &str {
+        self.token.body()
+    }
+
+    /// Was this unary operator prefix (or postfix)?
+    pub fn is_prefix(&self) -> bool {
+        self.is_prefix
+    }
+
+    /// Get a operand, the expression it's applied to.
+    pub fn operand(&self) -> &Expression {
+        self.operand.as_ref()
+    }
+}
+
+impl Syntax for Unary<'_> {
+    const NAME: &'static str = "a unary operator";
+
+    fn span(&self) -> Span {
+        self.token.span() + self.operand.span()
+    }
+}
+
+#[derive(Debug)]
+pub struct Binary<'a> {
+    token: Token<'a>,
+    operands: Box<(Expression<'a>, Expression<'a>)>,
+}
+
+impl<'a> Binary<'a> {
+    pub fn new(
+        token: Token<'a>,
+        lhs: Expression<'a>,
+        rhs: Expression<'a>,
+    ) -> Binary<'a> {
+        Binary {
+            token,
+            operands: Box::new((lhs, rhs)),
+        }
+    }
+
+    /// The body of the operator token.
+    pub fn operator(&self) -> &str {
+        self.token.body()
+    }
+
+    /// Get a left hand side of the binary expression.
+    pub fn left(&self) -> &Expression {
+        &self.operands.0
+    }
+
+    /// Get a right hand side of the binary expression.
+    pub fn right(&self) -> &Expression {
+        &self.operands.1
+    }
+}
+
+impl Syntax for Binary<'_> {
+    const NAME: &'static str = "a binary operator";
+
+    fn span(&self) -> Span {
+        self.left().span() + self.right().span()
+    }
+}

--- a/src/syntax/src/operator.rs
+++ b/src/syntax/src/operator.rs
@@ -42,6 +42,11 @@ impl<'a> Unary<'a> {
         self.token.body()
     }
 
+    /// The span of the operator token.
+    pub fn operator_span(&self) -> Span {
+        self.token.span()
+    }
+
     /// Was this unary operator prefix (or postfix)?
     pub fn is_prefix(&self) -> bool {
         self.is_prefix
@@ -82,6 +87,11 @@ impl<'a> Binary<'a> {
     /// The body of the operator token.
     pub fn operator(&self) -> &str {
         self.token.body()
+    }
+
+    /// The span of the operator token.
+    pub fn operator_span(&self) -> Span {
+        self.token.span()
     }
 
     /// Get a left hand side of the binary expression.


### PR DESCRIPTION
Implements operator parsing with full support for precedence, associativity, and reusing the same operator in prefix, postfix and infix positions. 

The system should be flexible enough to give us options later on how we want to do user-defined operators. We don't expose the underlying integers in `Precedence` to allow a move to a proper partial ordering later if desired.

The usual C-like operators compile directly into the appropriate opcodes for now, but eventually we'll want a better system for built-ins. The new opcodes (like `Op::Add`) are not yet implemented in the runtime.


